### PR TITLE
layer.conf: use override syntax for CORE_IMAGE_EXTRA_INSTALL

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,4 +17,4 @@ BBMASK += "bt-start_%.bbappend"
 BBMASK += "${@bb.utils.contains('BBFILE_COLLECTIONS', 'fsl-bsp-release', '', 'nnshark_%.bbappend', d)}"
 BBMASK += "meta-compulab/recipes-desktop/cl-growfs-rootfs/cl-growfs-rootfs.bb"
 
-CORE_IMAGE_EXTRA_INSTALL:compulab-mx8mp += " cl-bootcmd "
+CORE_IMAGE_EXTRA_INSTALL:append:compulab-mx8mp = " cl-bootcmd "


### PR DESCRIPTION
mixing the override syntax with += operator does not work as expected in some situations.

Make use of the override syntax, like it is done in local.conf (templates/local-extra.conf.append)